### PR TITLE
Fix news list layout

### DIFF
--- a/src/app/shared/components/news-article-card/news-article-card.component.scss
+++ b/src/app/shared/components/news-article-card/news-article-card.component.scss
@@ -27,8 +27,6 @@
     flex-direction: column;
     gap: 1rem;
     height: 400px;
-    margin-block-start: auto;
-    margin-block-end: auto;
   }
 }
 
@@ -42,9 +40,10 @@
 .description {
   text-overflow: ellipsis;
   color: vars.$color-primary-text;
+  overflow: hidden;
+  margin-bottom: auto;
 }
 .read-more {
-  margin-top: auto;
   margin-left: auto;
   color: vars.$color-primary;
   text-decoration: none;


### PR DESCRIPTION
This pull request makes adjustments to the styling of the `news-article-card` component to improve layout consistency and text overflow handling. The most important changes involve removing redundant vertical margins and ensuring proper alignment and overflow behavior for the description text.

Styling adjustments for layout and text handling:

* [`src/app/shared/components/news-article-card/news-article-card.component.scss`](diffhunk://#diff-11818f2f3602d724b8e693a251cc8a6501d4b8b144139dd603d528d12b0f8676L30-L31): Removed `margin-block-start` and `margin-block-end` from the card container, likely to eliminate unnecessary vertical spacing.
* [`src/app/shared/components/news-article-card/news-article-card.component.scss`](diffhunk://#diff-11818f2f3602d724b8e693a251cc8a6501d4b8b144139dd603d528d12b0f8676R43-L47): Added `overflow: hidden` and `margin-bottom: auto` to the `.description` class to handle text overflow and ensure proper alignment.